### PR TITLE
Retrait d'un import inutilisé

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
 import psycopg2
 from psycopg2.extras import RealDictCursor
 from dotenv import load_dotenv


### PR DESCRIPTION
## Résumé
- suppression de l'import `RedirectResponse` devenu inutile dans `main.py`

## Tests
- `flake8` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_b_687e9ada6c54832a9f63ceb63fb993ac