### PR TITLE
Ajout README et exemple d'environnement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Station72
+
+Cette application FastAPI permet de gérer un catalogue de jeux stockés dans une base de données PostgreSQL. Elle fournit une petite interface web (Jinja2) pour afficher la liste des jeux.
+
+## Installation
+
+1. Créez un environnement virtuel Python 3.13 ou plus :
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Installez les dépendances définies dans `pyproject.toml` avec `pip` :
+   ```bash
+   pip install -e .
+   ```
+
+## Variables d'environnement
+
+L'application s'appuie sur plusieurs variables à définir dans un fichier `.env` ou dans votre environnement :
+
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+
+Vous trouverez un exemple dans `env.example`.

--- a/env.example
+++ b/env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=ma_base
+DB_USER=mon_utilisateur
+DB_PASSWORD=mon_mot_de_passe


### PR DESCRIPTION
## Résumé
- créer `env.example` pour documenter les variables d'environnement
- écrire un README en français avec l'objectif de l'application et l'installation des dépendances

## Tests
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_687e9add2e7c832a8e96741434f8a7e1