### PR TITLE
Ajout de la gestion des pages d’un jeu

### DIFF
--- a/templates/add_jeu.html
+++ b/templates/add_jeu.html
@@ -44,6 +44,33 @@
                 <a href="/jeux" class="btn btn-secondary">Annuler</a>
             </div>
         </form>
+
+        {% if jeu %}
+        <h2>Pages du jeu</h2>
+        <a href="/pages/add?jeu_id={{ jeu.id_jeu }}" class="btn btn-primary">Ajouter</a>
+        <table>
+            <thead>
+                <tr>
+                    <th>Ordre</th>
+                    <th>Titre</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for page in pages %}
+                <tr>
+                    <td>{{ page.ordre }}</td>
+                    <td>{{ page.titre }}</td>
+                    <td>
+                        <a href="/pages/edit/{{ page.id_page }}" class="btn btn-secondary">Modifier</a>
+                        <a href="/pages/delete/{{ page.id_page }}" class="btn btn-danger" onclick="return confirm('Êtes-vous sûr de vouloir supprimer cette page ?');">Supprimer</a>
+                        <a href="/pages/duplicate/{{ page.id_page }}" class="btn btn-secondary">Dupliquer</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
     </div>
 </body>
 </html>

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    {% if page %}
+    <title>Modifier une page</title>
+    {% else %}
+    <title>Ajouter une page</title>
+    {% endif %}
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        {% if page %}
+        <h1>✏️ Modifier une page</h1>
+        <form action="/pages/edit/{{ page.id_page }}" method="post">
+        {% else %}
+        <h1>➕ Ajouter une page</h1>
+        <form action="/pages/add" method="post">
+        {% endif %}
+            <input type="hidden" name="jeu_id" value="{{ page.id_jeu if page else jeu_id }}">
+            <div class="form-inline">
+                <div class="form-group">
+                    <label for="titre">Titre :</label>
+                    <input type="text" id="titre" name="titre" value="{{ page.titre if page else '' }}" required>
+                </div>
+                <div class="form-group">
+                    <label for="ordre">Ordre :</label>
+                    <input type="number" id="ordre" name="ordre" value="{{ page.ordre if page else 0 }}" required>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="contenu">Contenu :</label>
+                <textarea id="contenu" name="contenu" rows="4">{{ page.contenu if page else '' }}</textarea>
+            </div>
+            <div>
+                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                <a href="/jeux/edit/{{ page.id_jeu if page else jeu_id }}" class="btn btn-secondary">Annuler</a>
+            </div>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Résumé
- affichage des pages d’un jeu lors de l’édition
- ajout des actions sur les pages (ajouter, modifier, supprimer, dupliquer)
- nouveau template pour le formulaire des pages

## Tests
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_687ea54decc0832aa6a00df2b03649a9