### PR TITLE
Ajout musique et image de fond

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Vous trouverez un exemple dans `env.example`.
 
 ## Changement de schéma
 
-La table `pages` possède maintenant deux colonnes supplémentaires :
+La table `pages` possède maintenant quatre colonnes supplémentaires :
 
 - `delai_fermeture` : temps en secondes avant fermeture automatique d'une page ;
-- `page_suivante` : identifiant de la page vers laquelle effectuer la transition automatique.
+- `page_suivante` : identifiant de la page vers laquelle effectuer la transition automatique ;
+- `musique` : chemin vers la musique associée à la page ;
+- `image_fond` : image d'arrière-plan de la page.

--- a/Station72.session.sql
+++ b/Station72.session.sql
@@ -1,3 +1,5 @@
 ALTER TABLE pages
 ADD COLUMN delai_fermeture INTEGER DEFAULT NULL COMMENT 'Délai en secondes avant fermeture automatique',
-ADD COLUMN page_suivante INTEGER DEFAULT NULL COMMENT 'id_page cible en cas de transition automatique';
+ADD COLUMN page_suivante INTEGER DEFAULT NULL COMMENT 'id_page cible en cas de transition automatique',
+ADD COLUMN musique TEXT DEFAULT NULL COMMENT 'Chemin du fichier musique',
+ADD COLUMN image_fond TEXT DEFAULT NULL COMMENT 'Chemin de l''image de fond';

--- a/main.py
+++ b/main.py
@@ -147,13 +147,24 @@ def add_page(
     ordre: int = Form(...),
     delai_fermeture: int = Form(0),
     page_suivante: int | None = Form(None),
+    musique: str = Form(""),
+    image_fond: str = Form(""),
     contenu: str = Form(""),
 ):
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, contenu) VALUES (%s, %s, %s, %s, %s, %s)",
-                (jeu_id, titre, ordre, delai_fermeture, page_suivante, contenu),
+                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                (
+                    jeu_id,
+                    titre,
+                    ordre,
+                    delai_fermeture,
+                    page_suivante,
+                    musique,
+                    image_fond,
+                    contenu,
+                ),
             )
             conn.commit()
     return RedirectResponse(url=f"/jeux/edit/{jeu_id}", status_code=303)
@@ -175,13 +186,24 @@ def edit_page(
     ordre: int = Form(...),
     delai_fermeture: int = Form(0),
     page_suivante: int | None = Form(None),
+    musique: str = Form(""),
+    image_fond: str = Form(""),
     contenu: str = Form(""),
 ):
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE pages SET titre=%s, ordre=%s, delai_fermeture=%s, page_suivante=%s, contenu=%s WHERE id_page=%s",
-                (titre, ordre, delai_fermeture, page_suivante, contenu, page_id),
+                "UPDATE pages SET titre=%s, ordre=%s, delai_fermeture=%s, page_suivante=%s, musique=%s, image_fond=%s, contenu=%s WHERE id_page=%s",
+                (
+                    titre,
+                    ordre,
+                    delai_fermeture,
+                    page_suivante,
+                    musique,
+                    image_fond,
+                    contenu,
+                    page_id,
+                ),
             )
             cur.execute("SELECT id_jeu FROM pages WHERE id_page=%s", (page_id,))
             jeu_id = cur.fetchone()[0]
@@ -205,18 +227,20 @@ def duplicate_page(page_id: int):
     with get_conn() as conn:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
-                "SELECT id_jeu, titre, ordre, delai_fermeture, page_suivante, contenu FROM pages WHERE id_page=%s",
+                "SELECT id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, contenu FROM pages WHERE id_page=%s",
                 (page_id,),
             )
             page = cur.fetchone()
             cur.execute(
-                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, contenu) VALUES (%s, %s, %s, %s, %s, %s)",
+                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     page["id_jeu"],
                     page["titre"],
                     page["ordre"],
                     page["delai_fermeture"],
                     page["page_suivante"],
+                    page["musique"],
+                    page["image_fond"],
                     page["contenu"],
                 ),
             )

--- a/templates/add_jeu.html
+++ b/templates/add_jeu.html
@@ -58,6 +58,8 @@
                     <th>Contenu</th>
                     <th>Délai (sec)</th>
                     <th>Page suivante</th>
+                    <th>Musique</th>
+                    <th>Image de fond</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -71,6 +73,8 @@
                     <td>{{ page.contenu }}</td>
                     <td>{{ page.delai_fermeture }}</td>
                     <td>{{ page.page_suivante }}</td>
+                    <td>{{ page.musique }}</td>
+                    <td>{{ page.image_fond }}</td>
                     <td>
                         <a href="/pages/edit/{{ page.id_page }}" class="btn btn-secondary">Modifier</a>
                         <a href="/pages/delete/{{ page.id_page }}" class="btn btn-danger" onclick="return confirm('Êtes-vous sûr de vouloir supprimer cette page ?');">Supprimer</a>

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -35,6 +35,14 @@
                 <label for="page_suivante">Page suivante :</label>
                 <input type="number" id="page_suivante" name="page_suivante" value="{{ page.page_suivante if page else '' }}">
             </div>
+            <div class="form-group">
+                <label for="musique">Musique :</label>
+                <input type="text" id="musique" name="musique" value="{{ page.musique if page else '' }}">
+            </div>
+            <div class="form-group">
+                <label for="image_fond">Image de fond :</label>
+                <input type="text" id="image_fond" name="image_fond" value="{{ page.image_fond if page else '' }}">
+            </div>
             </div>
             <div class="form-group">
                 <label for="contenu">Contenu :</label>


### PR DESCRIPTION
## Résumé
- Ajout des champs `musique` et `image_fond` dans la table `pages`
- Mise à jour des formulaires et des requêtes SQL
- Affichage des nouvelles colonnes dans l'interface d'administration
- Documentation du nouveau schéma

## Tests
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_687f59a79ce0832aa6c48ab49a6cd7e4