### PR TITLE
Réorganise le formulaire de page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -76,3 +76,7 @@ input[readonly] {
 .form-inline .form-group {
     flex: 1;
 }
+
+#ordre {
+    width: 80px;
+}

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -23,30 +23,32 @@
                     <label for="titre">Titre :</label>
                     <input type="text" id="titre" name="titre" value="{{ page.titre if page else '' }}" required>
                 </div>
-            <div class="form-group">
-                <label for="ordre">Ordre :</label>
-                <input type="number" id="ordre" name="ordre" value="{{ page.ordre if page else 0 }}" required>
+                <div class="form-group">
+                    <label for="ordre">Ordre :</label>
+                    <input type="number" id="ordre" name="ordre" value="{{ page.ordre if page else 0 }}" required>
+                </div>
+                <div class="form-group">
+                    <label for="delai_fermeture">Délai fermeture (sec) :</label>
+                    <input type="number" id="delai_fermeture" name="delai_fermeture" value="{{ page.delai_fermeture if page else 0 }}">
+                </div>
+                <div class="form-group">
+                    <label for="page_suivante">Page suivante :</label>
+                    <input type="number" id="page_suivante" name="page_suivante" value="{{ page.page_suivante if page else '' }}">
+                </div>
             </div>
-            <div class="form-group">
-                <label for="delai_fermeture">Délai fermeture (sec) :</label>
-                <input type="number" id="delai_fermeture" name="delai_fermeture" value="{{ page.delai_fermeture if page else 0 }}">
-            </div>
-            <div class="form-group">
-                <label for="page_suivante">Page suivante :</label>
-                <input type="number" id="page_suivante" name="page_suivante" value="{{ page.page_suivante if page else '' }}">
-            </div>
-            <div class="form-group">
-                <label for="musique">Musique :</label>
-                <input type="text" id="musique" name="musique" value="{{ page.musique if page else '' }}">
-            </div>
-            <div class="form-group">
-                <label for="image_fond">Image de fond :</label>
-                <input type="text" id="image_fond" name="image_fond" value="{{ page.image_fond if page else '' }}">
-            </div>
+            <div class="form-inline">
+                <div class="form-group">
+                    <label for="musique">Musique :</label>
+                    <input type="text" id="musique" name="musique" value="{{ page.musique if page else '' }}">
+                </div>
+                <div class="form-group">
+                    <label for="image_fond">Image de fond :</label>
+                    <input type="text" id="image_fond" name="image_fond" value="{{ page.image_fond if page else '' }}">
+                </div>
             </div>
             <div class="form-group">
                 <label for="contenu">Contenu :</label>
-                <textarea id="contenu" name="contenu" rows="4">{{ page.contenu if page else '' }}</textarea>
+                <textarea id="contenu" name="contenu" rows="12">{{ page.contenu if page else '' }}</textarea>
             </div>
             <div>
                 <button type="submit" class="btn btn-primary">Enregistrer</button>


### PR DESCRIPTION
## Résumé
- réarrangement des champs du formulaire de modification/ajout de page
- zone de saisie `ordre` réduite
- champ `Contenu` plus haut

## Tests
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687f5bd57744832ab359fbe976a2026f