### PR TITLE
Ajout d'une liste déroulante pour la page suivante

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,8 +135,15 @@ def delete_jeu(jeu_id: int):
 @app.get("/pages/add")
 def add_page_form(request: Request, jeu_id: int):
     """Formulaire d'ajout d'une page."""
+    with get_conn() as conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id_page, titre FROM pages WHERE id_jeu=%s ORDER BY ordre",
+                (jeu_id,),
+            )
+            pages = cur.fetchall()
     return templates.TemplateResponse(
-        "add_page.html", {"request": request, "jeu_id": jeu_id}
+        "add_page.html", {"request": request, "jeu_id": jeu_id, "pages": pages}
     )
 
 
@@ -178,13 +185,23 @@ def edit_page_form(request: Request, page_id: int):
             cur.execute("SELECT * FROM pages WHERE id_page=%s", (page_id,))
             page = cur.fetchone()
             cur.execute(
+                "SELECT id_page, titre FROM pages WHERE id_jeu=%s ORDER BY ordre",
+                (page["id_jeu"],),
+            )
+            pages = cur.fetchall()
+            cur.execute(
                 "SELECT * FROM transitions WHERE id_page_source=%s ORDER BY priorite, id_transition",
                 (page_id,),
             )
             transitions = cur.fetchall()
     return templates.TemplateResponse(
         "add_page.html",
-        {"request": request, "page": page, "transitions": transitions},
+        {
+            "request": request,
+            "page": page,
+            "transitions": transitions,
+            "pages": pages,
+        },
     )
 
 

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -33,7 +33,12 @@
                 </div>
                 <div class="form-group">
                     <label for="page_suivante">Page suivante :</label>
-                    <input type="number" id="page_suivante" name="page_suivante" value="{{ page.page_suivante if page else '' }}">
+                    <select id="page_suivante" name="page_suivante">
+                        <option value=""></option>
+                        {% for p in pages %}
+                        <option value="{{ p.id_page }}" {% if page and p.id_page == page.page_suivante %}selected{% endif %}>{{ p.titre }}</option>
+                        {% endfor %}
+                    </select>
                 </div>
             </div>
             <div class="form-inline">


### PR DESCRIPTION
## Résumé
- ajout de la liste des pages lors de l'ajout ou la modification d'une page
- transformation du champ `Page suivante` en liste déroulante affichant les titres

## Tests
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_687f7344d1a4832a8a28651e772b754a