### PR TITLE
Ajout d'une liste déroulante pour sélectionner la page cible

### DIFF
--- a/main.py
+++ b/main.py
@@ -261,8 +261,17 @@ def duplicate_page(page_id: int):
 @app.get("/transitions/add")
 def add_transition_form(request: Request, page_id: int):
     """Formulaire d'ajout d'une transition."""
+    with get_conn() as conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute("SELECT id_jeu FROM pages WHERE id_page=%s", (page_id,))
+            jeu_id = cur.fetchone()["id_jeu"]
+            cur.execute(
+                "SELECT id_page, titre FROM pages WHERE id_jeu=%s ORDER BY ordre",
+                (jeu_id,),
+            )
+            pages = cur.fetchall()
     return templates.TemplateResponse(
-        "add_transition.html", {"request": request, "page_id": page_id}
+        "add_transition.html", {"request": request, "page_id": page_id, "pages": pages}
     )
 
 
@@ -308,8 +317,19 @@ def edit_transition_form(request: Request, transition_id: int):
                 (transition_id,),
             )
             transition = cur.fetchone()
+            cur.execute(
+                "SELECT id_jeu FROM pages WHERE id_page=%s",
+                (transition["id_page_source"],),
+            )
+            jeu_id = cur.fetchone()["id_jeu"]
+            cur.execute(
+                "SELECT id_page, titre FROM pages WHERE id_jeu=%s ORDER BY ordre",
+                (jeu_id,),
+            )
+            pages = cur.fetchall()
     return templates.TemplateResponse(
-        "add_transition.html", {"request": request, "transition": transition}
+        "add_transition.html",
+        {"request": request, "transition": transition, "pages": pages},
     )
 
 

--- a/templates/add_transition.html
+++ b/templates/add_transition.html
@@ -25,7 +25,11 @@
                 </div>
                 <div class="form-group">
                     <label for="id_page_cible">Page cible :</label>
-                    <input type="number" id="id_page_cible" name="id_page_cible" value="{{ transition.id_page_cible if transition else '' }}" required>
+                    <select id="id_page_cible" name="id_page_cible" required>
+                        {% for p in pages %}
+                        <option value="{{ p.id_page }}" {% if transition and p.id_page == transition.id_page_cible %}selected{% endif %}>{{ p.id_page }} - {{ p.titre }}</option>
+                        {% endfor %}
+                    </select>
                 </div>
             </div>
             <div class="form-inline">


### PR DESCRIPTION
## Résumé
- affichage d'une liste des pages pour choisir la page cible d'une transition
- chargement des pages dans `add_transition_form` et `edit_transition_form`

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687f7378d5f0832a9f819e04bead22ee