### PR TITLE
Affiche le titre de la page cible

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,13 @@ def edit_page_form(request: Request, page_id: int):
             )
             pages = cur.fetchall()
             cur.execute(
-                "SELECT * FROM transitions WHERE id_page_source=%s ORDER BY priorite, id_transition",
+                """
+                SELECT t.*, p.titre AS page_cible_titre
+                FROM transitions t
+                JOIN pages p ON t.id_page_cible = p.id_page
+                WHERE t.id_page_source=%s
+                ORDER BY t.priorite, t.id_transition
+                """,
                 (page_id,),
             )
             transitions = cur.fetchall()

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -82,7 +82,7 @@
                 <tr>
                     <td>{{ t.id_transition }}</td>
                     <td>{{ t.intention }}</td>
-                    <td>{{ t.id_page_cible }}</td>
+                    <td>{{ t.page_cible_titre }}</td>
                     <td>{{ t.condition_flag }}</td>
                     <td>{{ t.valeur_condition }}</td>
                     <td>{{ t.priorite }}</td>


### PR DESCRIPTION
## Résumé
- affiche le titre de la page cible dans la liste des transitions d'une page
- joint la table `pages` pour récupérer ce titre

## Tests
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687f75e702a0832a8c71ce000f8f5750