### PR TITLE
Ajout du moteur de jeu narratif

### DIFF
--- a/jouer.py
+++ b/jouer.py
@@ -1,0 +1,130 @@
+from fastapi import FastAPI, Request, Form
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from psycopg2.extras import RealDictCursor
+from psycopg2.pool import SimpleConnectionPool
+from contextlib import contextmanager
+from dotenv import load_dotenv
+import os
+import uvicorn
+
+load_dotenv()
+
+DB_HOST = os.getenv("DB_HOST")
+DB_PORT = os.getenv("DB_PORT")
+DB_NAME = os.getenv("DB_NAME")
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
+templates = Jinja2Templates(directory="templates")
+
+pool: SimpleConnectionPool | None = None
+
+@app.on_event("startup")
+def startup() -> None:
+    """Initialise la connexion à la base de données."""
+    global pool
+    pool = SimpleConnectionPool(
+        minconn=1,
+        maxconn=10,
+        host=DB_HOST,
+        port=DB_PORT,
+        dbname=DB_NAME,
+        user=DB_USER,
+        password=DB_PASSWORD,
+    )
+
+@app.on_event("shutdown")
+def shutdown() -> None:
+    """Ferme le pool de connexions."""
+    if pool:
+        pool.closeall()
+
+@contextmanager
+def get_conn():
+    assert pool is not None, "Le pool de connexions n'est pas initialisé"
+    conn = pool.getconn()
+    try:
+        yield conn
+    finally:
+        pool.putconn(conn)
+
+
+def charger_page(conn, page_id: int):
+    """Récupère une page par son identifiant."""
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute("SELECT * FROM pages WHERE id_page=%s", (page_id,))
+        return cur.fetchone()
+
+
+def charger_jeu(conn, jeu_id: int):
+    """Récupère un jeu par son identifiant."""
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute("SELECT * FROM jeux WHERE id_jeu=%s", (jeu_id,))
+        return cur.fetchone()
+
+
+@app.get("/play/{jeu_id}")
+def demarrer_jeu(request: Request, jeu_id: int):
+    """Affiche la première page du jeu."""
+    with get_conn() as conn:
+        jeu = charger_jeu(conn, jeu_id)
+        if not jeu:
+            return templates.TemplateResponse(
+                "erreur.html",
+                {"request": request, "message": "Jeu introuvable"},
+                status_code=404,
+            )
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT * FROM pages WHERE id_jeu=%s ORDER BY ordre LIMIT 1",
+                (jeu_id,),
+            )
+            page = cur.fetchone()
+    return templates.TemplateResponse(
+        "play_page.html",
+        {"request": request, "jeu": jeu, "page": page, "message": ""},
+    )
+
+
+@app.post("/play/{jeu_id}/{page_id}")
+def jouer_page(request: Request, jeu_id: int, page_id: int, saisie: str = Form("")):
+    """Traite la saisie du joueur et applique la transition."""
+    with get_conn() as conn:
+        jeu = charger_jeu(conn, jeu_id)
+        page = charger_page(conn, page_id)
+        if not page:
+            return templates.TemplateResponse(
+                "erreur.html",
+                {"request": request, "message": "Page introuvable"},
+                status_code=404,
+            )
+        # Recherche de la transition correspondante
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT * FROM transitions
+                WHERE id_page_source=%s
+                  AND %s ILIKE '%%' || intention || '%%'
+                ORDER BY priorite, id_transition
+                LIMIT 1
+                """,
+                (page_id, saisie),
+            )
+            transition = cur.fetchone()
+        if transition:
+            # On affiche la réponse système éventuelle puis on charge la page cible
+            message = transition.get("reponse_systeme") or ""
+            page = charger_page(conn, transition["id_page_cible"])
+        else:
+            message = "Je n'ai pas compris…"
+    return templates.TemplateResponse(
+        "play_page.html",
+        {"request": request, "jeu": jeu, "page": page, "message": message},
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run("jouer:app", host="127.0.0.1", port=8001, reload=True)

--- a/templates/erreur.html
+++ b/templates/erreur.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Erreur</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+    <p>{{ message }}</p>
+</div>
+</body>
+</html>

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ jeu.titre }}</title>
+    <link rel="stylesheet" href="/static/style.css">
+    {% if page.image_fond %}
+    <style>
+        body {
+            background-image: url('/static/jeux/{{ jeu.id_jeu }}/{{ page.image_fond }}');
+            background-size: cover;
+        }
+    </style>
+    {% endif %}
+</head>
+<body>
+<div class="container">
+    <div>{{ page.contenu | safe }}</div>
+    {% if page.musique %}
+    <audio controls autoplay loop>
+        <source src="/static/jeux/{{ jeu.id_jeu }}/{{ page.musique }}" type="audio/mpeg">
+    </audio>
+    {% endif %}
+    {% if page.video %}
+    <video controls autoplay>
+        <source src="/static/jeux/{{ jeu.id_jeu }}/{{ page.video }}" type="video/mp4">
+    </video>
+    {% endif %}
+    {% if message %}
+    <p style="color:red">{{ message }}</p>
+    {% endif %}
+    <form action="/play/{{ jeu.id_jeu }}/{{ page.id_page }}" method="post">
+        <input type="text" name="saisie" autofocus>
+        <button type="submit">Envoyer</button>
+    </form>
+</div>
+{% if page.delai_fermeture and page.page_suivante %}
+<script>
+setTimeout(function(){
+    window.location.href = '/play/{{ jeu.id_jeu }}/{{ page.page_suivante }}';
+}, {{ page.delai_fermeture }} * 1000);
+</script>
+{% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Résumé
- création d'un fichier `jouer.py` mettant en place le moteur interactif basé sur FastAPI
- ajout des templates `play_page.html` et `erreur.html`

## Tests
- `python -m py_compile jouer.py`


------
https://chatgpt.com/codex/tasks/task_b_687f8be6d908832aa7abeee928415201