### PR TITLE
Ajout des textes d'énigme

### DIFF
--- a/Station72.session.sql
+++ b/Station72.session.sql
@@ -4,6 +4,11 @@ ADD COLUMN page_suivante INTEGER DEFAULT NULL COMMENT 'id_page cible en cas de t
 ADD COLUMN musique TEXT DEFAULT NULL COMMENT 'Chemin du fichier musique',
 ADD COLUMN image_fond TEXT DEFAULT NULL COMMENT 'Chemin de l''image de fond';
 
+ALTER TABLE pages
+ADD COLUMN enigme_texte TEXT DEFAULT NULL COMMENT 'Texte de l''énigme',
+ADD COLUMN bouton_texte TEXT DEFAULT NULL COMMENT 'Libellé du bouton',
+ADD COLUMN erreur_texte TEXT DEFAULT NULL COMMENT 'Message en cas d''erreur';
+
 CREATE TABLE transitions (
     id_transition SERIAL PRIMARY KEY,
     id_page_source INTEGER NOT NULL,

--- a/main.py
+++ b/main.py
@@ -184,13 +184,16 @@ def add_page(
     page_suivante: str = Form(""),
     musique: str = Form(""),
     image_fond: str = Form(""),
+    enigme_texte: str = Form(""),
+    bouton_texte: str = Form(""),
+    erreur_texte: str = Form(""),
     contenu: str = Form(""),
 ):
     with get_conn() as conn:
         with conn.cursor() as cur:
             next_page = int(page_suivante) if page_suivante else None
             cur.execute(
-                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, enigme_texte, bouton_texte, erreur_texte, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     jeu_id,
                     titre,
@@ -199,6 +202,9 @@ def add_page(
                     next_page,
                     musique,
                     image_fond,
+                    enigme_texte,
+                    bouton_texte,
+                    erreur_texte,
                     contenu,
                 ),
             )
@@ -248,13 +254,16 @@ def edit_page(
     page_suivante: str = Form(""),
     musique: str = Form(""),
     image_fond: str = Form(""),
+    enigme_texte: str = Form(""),
+    bouton_texte: str = Form(""),
+    erreur_texte: str = Form(""),
     contenu: str = Form(""),
 ):
     with get_conn() as conn:
         with conn.cursor() as cur:
             next_page = int(page_suivante) if page_suivante else None
             cur.execute(
-                "UPDATE pages SET titre=%s, ordre=%s, delai_fermeture=%s, page_suivante=%s, musique=%s, image_fond=%s, contenu=%s WHERE id_page=%s",
+                "UPDATE pages SET titre=%s, ordre=%s, delai_fermeture=%s, page_suivante=%s, musique=%s, image_fond=%s, enigme_texte=%s, bouton_texte=%s, erreur_texte=%s, contenu=%s WHERE id_page=%s",
                 (
                     titre,
                     ordre,
@@ -262,6 +271,9 @@ def edit_page(
                     next_page,
                     musique,
                     image_fond,
+                    enigme_texte,
+                    bouton_texte,
+                    erreur_texte,
                     contenu,
                     page_id,
                 ),
@@ -288,12 +300,12 @@ def duplicate_page(page_id: int):
     with get_conn() as conn:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
-                "SELECT id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, contenu FROM pages WHERE id_page=%s",
+                "SELECT id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, enigme_texte, bouton_texte, erreur_texte, contenu FROM pages WHERE id_page=%s",
                 (page_id,),
             )
             page = cur.fetchone()
             cur.execute(
-                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, enigme_texte, bouton_texte, erreur_texte, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     page["id_jeu"],
                     page["titre"],
@@ -302,6 +314,9 @@ def duplicate_page(page_id: int):
                     page["page_suivante"],
                     page["musique"],
                     page["image_fond"],
+                    page["enigme_texte"],
+                    page["bouton_texte"],
+                    page["erreur_texte"],
                     page["contenu"],
                 ),
             )

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -51,6 +51,20 @@
                     <input type="text" id="image_fond" name="image_fond" value="{{ page.image_fond if page else '' }}">
                 </div>
             </div>
+            <div class="form-inline">
+                <div class="form-group">
+                    <label for="enigme_texte">Énigme :</label>
+                    <input type="text" id="enigme_texte" name="enigme_texte" value="{{ page.enigme_texte if page else '' }}">
+                </div>
+                <div class="form-group">
+                    <label for="bouton_texte">Texte bouton :</label>
+                    <input type="text" id="bouton_texte" name="bouton_texte" value="{{ page.bouton_texte if page else '' }}">
+                </div>
+                <div class="form-group">
+                    <label for="erreur_texte">Message erreur :</label>
+                    <input type="text" id="erreur_texte" name="erreur_texte" value="{{ page.erreur_texte if page else '' }}">
+                </div>
+            </div>
             <div class="form-group">
                 <label for="contenu">Contenu :</label>
                 <textarea id="contenu" name="contenu" rows="12">{{ page.contenu if page else '' }}</textarea>


### PR DESCRIPTION
## Résumé
- ajout de trois nouveaux champs dans `pages`
- prise en charge de ces colonnes lors de l'ajout, la modification et la duplication de page
- formulaire modifié pour afficher ces zones avant le contenu

## Test
- `python -m py_compile main.py jouer.py`

------
https://chatgpt.com/codex/tasks/task_b_687fa467eeb8832aa31900d17dff7da6