### PR TITLE
Fix static file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Station72
 
-Cette application FastAPI permet de gérer un catalogue de jeux stockés dans une base de données PostgreSQL. Elle fournit une petite interface web (Jinja2) pour afficher la liste des jeux. Chaque jeu dispose maintenant de son propre fichier de style situé dans `/static/Jeux/<slug>/style.css`.
+Cette application FastAPI permet de gérer un catalogue de jeux stockés dans une base de données PostgreSQL. Elle fournit une petite interface web (Jinja2) pour afficher la liste des jeux. Chaque jeu dispose maintenant de son propre fichier de style situé dans `/static/jeux/<slug>/style.css`.
 
 ## Installation
 

--- a/main.py
+++ b/main.py
@@ -65,9 +65,9 @@ def slugify(text: str) -> str:
 
 
 def ensure_game_dirs(title: str) -> None:
-    """Crée l'arborescence /static/Jeux/<slug>/ si nécessaire."""
+    """Crée l'arborescence /static/jeux/<slug>/ si nécessaire."""
     slug = slugify(title)
-    base = os.path.join("static", "Jeux", slug)
+    base = os.path.join("static", "jeux", slug)
     os.makedirs(base, exist_ok=True)
     for sub in ("images", "audio", "video", "html"):
         os.makedirs(os.path.join(base, sub), exist_ok=True)

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="utf-8">
     <title>{{ jeu.titre }}</title>
-    <link rel="stylesheet" href="/static/Jeux/{{ slug }}/style.css">
+    <link rel="stylesheet" href="/static/jeux/{{ slug }}/style.css">
     {% if page.image_fond %}
     <style>
         body {
-            background-image: url('/static/Jeux/{{ jeu.id_jeu }}/{{ page.image_fond }}');
+            background-image: url('/static/jeux/{{ slug }}/images/{{ page.image_fond }}');
             background-size: cover;
         }
     </style>
@@ -18,12 +18,12 @@
     <div>{{ page.contenu | safe }}</div>
     {% if page.musique %}
     <audio controls autoplay loop>
-        <source src="/static/Jeux/{{ jeu.id_jeu }}/{{ page.musique }}" type="audio/mpeg">
+        <source src="/static/jeux/{{ slug }}/audio/{{ page.musique }}" type="audio/mpeg">
     </audio>
     {% endif %}
     {% if page.video %}
     <video controls autoplay>
-        <source src="/static/Jeux/{{ jeu.id_jeu }}/{{ page.video }}" type="video/mp4">
+        <source src="/static/jeux/{{ slug }}/video/{{ page.video }}" type="video/mp4">
     </video>
     {% endif %}
     {% if message %}


### PR DESCRIPTION
## Summary
- point static asset paths to `static/jeux` rather than `static/Jeux`
- adjust `ensure_game_dirs` to create lowercase folders
- update README usage example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fdfffac2c832a90f430fd8e29fbb6