### PR TITLE
Cacher le lecteur audio pendant la lecture

### DIFF
--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -17,7 +17,7 @@
 <div class="container">
     <div>{{ page.contenu | safe }}</div>
     {% if page.musique %}
-    <audio controls autoplay loop>
+    <audio autoplay loop style="display:none;">
         <source src="/static/jeux/{{ slug }}/audio/{{ page.musique }}" type="audio/mpeg">
     </audio>
     {% endif %}


### PR DESCRIPTION
## Résumé
- cacher le lecteur audio pour qu'il ne s'affiche plus

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fe19e29d4832a9da18c2d22fe26fd