### PR TITLE
Reste sur l'écran d'édition d'une page après sauvegarde

### DIFF
--- a/main.py
+++ b/main.py
@@ -278,10 +278,8 @@ def edit_page(
                     page_id,
                 ),
             )
-            cur.execute("SELECT id_jeu FROM pages WHERE id_page=%s", (page_id,))
-            jeu_id = cur.fetchone()[0]
             conn.commit()
-    return RedirectResponse(url=f"/jeux/edit/{jeu_id}", status_code=303)
+    return RedirectResponse(url=f"/pages/edit/{page_id}", status_code=303)
 
 
 @app.get("/pages/delete/{page_id}")


### PR DESCRIPTION
## Résumé
- lors de l'enregistrement d'une page, rester sur l'écran d'édition au lieu de revenir à l'édition du jeu

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fe2e7f0e8832a862f00e061b58587