### PR TITLE
Aligner le formulaire de jeu en bas d’écran

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -93,3 +93,12 @@ input[readonly] {
     display: none;
     z-index: 1000;
 }
+
+.text-container-bottom {
+    position: absolute;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    text-align: center;
+}

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -35,13 +35,15 @@
     setTimeout(() => { popup.style.display = 'none'; }, 3000);
     </script>
     {% endif %}
-    <form class="input-container" action="/play/{{ jeu.id_jeu }}/{{ page.id_page }}" method="post">
-        {% if page.enigme_texte %}
-        <label for="saisie">{{ page.enigme_texte }}</label>
-        {% endif %}
-        <input class="input-lcars" type="text" id="saisie" name="saisie" autofocus>
-        <button class="btn-lcars" type="submit">{{ page.bouton_texte or 'Envoyer' }}</button>
-    </form>
+    <div class="text-container text-container-bottom">
+        <form class="input-container" action="/play/{{ jeu.id_jeu }}/{{ page.id_page }}" method="post">
+            {% if page.enigme_texte %}
+            <label for="saisie">{{ page.enigme_texte }}</label>
+            {% endif %}
+            <input class="input-lcars" type="text" id="saisie" name="saisie" autofocus>
+            <button class="btn-lcars" type="submit">{{ page.bouton_texte or 'Envoyer' }}</button>
+        </form>
+    </div>
 </div>
 {% if page.delai_fermeture and page.page_suivante %}
 <script>


### PR DESCRIPTION
## Résumé
- encapsule le formulaire de `play_page.html` dans un conteneur
- ajoute le style `.text-container-bottom` pour positionner ce conteneur en bas de page

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fea6afcb0832ab0cae1e781d120f7