### PR TITLE
Corrige liens Jouer avec l'hôte courant

### DIFF
--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -73,7 +73,7 @@
                 <button type="submit" class="btn btn-primary">Enregistrer</button>
                 <a href="/jeux/edit/{{ page.id_jeu if page else jeu_id }}" class="btn btn-secondary">Annuler</a>
                 {% if page %}
-                <a href="http://127.0.0.1:8001/play/{{ page.id_jeu }}/{{ page.id_page }}" class="btn btn-primary" target="_blank">Jouer</a>
+                <a href="{{ request.url_for('afficher_page', jeu_id=page.id_jeu, page_id=page.id_page) }}" class="btn btn-primary" target="_blank">Jouer</a>
                 {% endif %}
             </div>
         </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
                     <td>
                         <a href="/jeux/edit/{{ jeu.id_jeu }}" class="btn btn-secondary">Modifier</a>
                         <a href="/jeux/delete/{{ jeu.id_jeu }}" class="btn btn-danger" onclick="return confirm('Êtes-vous sûr de vouloir supprimer ce jeu ?');">Supprimer</a>
-                        <a href="http://127.0.0.1:8001/play/{{ jeu.id_jeu }}" target="_blank" class="btn btn-primary">Jouer</a>
+                        <a href="{{ request.url_for('demarrer_jeu', jeu_id=jeu.id_jeu) }}" target="_blank" class="btn btn-primary">Jouer</a>
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
## Résumé
- les boutons **Jouer** de l'accueil et de la page d'édition utilisaient l'adresse fixe `http://127.0.0.1:8001`
- ces liens utilisent désormais `request.url_for(...)` afin de prendre l'adresse et le port du navigateur

## Test
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68809fbc8f68832a8662eceda01d11f5