### PR TITLE
Fix routing for game launch

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,20 @@ def ensure_game_dirs(title: str) -> None:
     for sub in ("images", "audio", "video", "html"):
         os.makedirs(os.path.join(base, sub), exist_ok=True)
 
+
+def charger_page(conn, page_id: int):
+    """Récupère une page par son identifiant."""
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute("SELECT * FROM pages WHERE id_page=%s", (page_id,))
+        return cur.fetchone()
+
+
+def charger_jeu(conn, jeu_id: int):
+    """Récupère un jeu par son identifiant."""
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute("SELECT * FROM jeux WHERE id_jeu=%s", (jeu_id,))
+        return cur.fetchone()
+
 @app.get("/jeux")
 def list_jeux(request: Request):
     with get_conn() as conn:
@@ -486,6 +500,85 @@ def duplicate_transition(transition_id: int):
             )
             conn.commit()
     return RedirectResponse(url=f"/pages/edit/{t['id_page_source']}", status_code=303)
+
+
+@app.get("/play/{jeu_id}")
+def demarrer_jeu(request: Request, jeu_id: int):
+    """Affiche la première page du jeu."""
+    with get_conn() as conn:
+        jeu = charger_jeu(conn, jeu_id)
+        if not jeu:
+            return templates.TemplateResponse(
+                "erreur.html",
+                {"request": request, "message": "Jeu introuvable"},
+                status_code=404,
+            )
+        slug = slugify(jeu["titre"])
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT * FROM pages WHERE id_jeu=%s ORDER BY ordre LIMIT 1",
+                (jeu_id,),
+            )
+            page = cur.fetchone()
+    return templates.TemplateResponse(
+        "play_page.html",
+        {"request": request, "jeu": jeu, "page": page, "message": "", "slug": slug},
+    )
+
+
+@app.get("/play/{jeu_id}/{page_id}")
+def afficher_page(request: Request, jeu_id: int, page_id: int):
+    """Affiche simplement une page sans traitement de saisie."""
+    with get_conn() as conn:
+        jeu = charger_jeu(conn, jeu_id)
+        page = charger_page(conn, page_id)
+        if not page or not jeu:
+            return templates.TemplateResponse(
+                "erreur.html",
+                {"request": request, "message": "Page introuvable"},
+                status_code=404,
+            )
+        slug = slugify(jeu["titre"])
+    return templates.TemplateResponse(
+        "play_page.html",
+        {"request": request, "jeu": jeu, "page": page, "message": "", "slug": slug},
+    )
+
+
+@app.post("/play/{jeu_id}/{page_id}")
+def jouer_page(request: Request, jeu_id: int, page_id: int, saisie: str = Form("")):
+    """Traite la saisie du joueur et applique la transition."""
+    with get_conn() as conn:
+        jeu = charger_jeu(conn, jeu_id)
+        page = charger_page(conn, page_id)
+        if not page:
+            return templates.TemplateResponse(
+                "erreur.html",
+                {"request": request, "message": "Page introuvable"},
+                status_code=404,
+            )
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT * FROM transitions
+                WHERE id_page_source=%s
+                  AND %s ILIKE '%%' || intention || '%%'
+                ORDER BY priorite, id_transition
+                LIMIT 1
+                """,
+                (page_id, saisie),
+            )
+            transition = cur.fetchone()
+        if transition:
+            message = transition.get("reponse_systeme") or ""
+            page = charger_page(conn, transition["id_page_cible"])
+        else:
+            message = page.get("erreur_texte") or "Je n'ai pas compris…"
+    slug = slugify(jeu["titre"])
+    return templates.TemplateResponse(
+        "play_page.html",
+        {"request": request, "jeu": jeu, "page": page, "message": message, "slug": slug},
+    )
 
 if __name__ == "__main__":
     


### PR DESCRIPTION
## Summary
- expose game playing endpoints directly in `main.py`
- add helpers to load games and pages

## Testing
- `python -m py_compile main.py jouer.py`

------
https://chatgpt.com/codex/tasks/task_b_6880a359495c832ab033daffce982714