### PR TITLE
Ajout de la synthèse vocale pour les messages

### DIFF
--- a/templates/erreur.html
+++ b/templates/erreur.html
@@ -7,6 +7,11 @@
 </head>
 <body>
 <div id="popup" class="popup">{{ message }}</div>
+{% if audio %}
+<audio autoplay>
+    <source src="{{ audio }}" type="audio/wav">
+</audio>
+{% endif %}
 <script>
 const popup = document.getElementById('popup');
 popup.style.display = 'block';

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -49,8 +49,13 @@
         <source src="/static/jeux/{{ slug }}/video/{{ page.video }}" type="video/mp4">
     </video>
     {% endif %}
-    {% if message %}
+{% if message %}
     <div id="popup" class="popup">{{ message }}</div>
+    {% if audio %}
+    <audio autoplay>
+        <source src="{{ audio }}" type="audio/wav">
+    </audio>
+    {% endif %}
     <script>
     const popup = document.getElementById('popup');
     popup.style.display = 'block';


### PR DESCRIPTION
## Résumé
- génération d'audio via XTTS dans `jouer.py`
- lecture automatique des messages d'erreur et des réponses dans `play_page.html` et `erreur.html`
- création du dossier `static/tts` pour stocker les fichiers générés

## Tests
- `python -m py_compile jouer.py`

------
https://chatgpt.com/codex/tasks/task_b_6880e853ab54832aa92bc887e1eef407