### PR TITLE
Ajout des champs de voie pour les jeux

### DIFF
--- a/Station72.session.sql
+++ b/Station72.session.sql
@@ -12,6 +12,10 @@ ADD COLUMN erreur_texte TEXT DEFAULT NULL COMMENT 'Message en cas d''erreur';
 ALTER TABLE jeux
 ADD COLUMN ia_nom TEXT DEFAULT NULL COMMENT 'Nom de l\'IA';
 
+ALTER TABLE jeux
+ADD COLUMN nom_de_la_voie TEXT DEFAULT NULL COMMENT 'Nom de la voie',
+ADD COLUMN voie_actif BOOLEAN DEFAULT FALSE COMMENT 'Voie active';
+
 CREATE TABLE transitions (
     id_transition SERIAL PRIMARY KEY,
     id_page_source INTEGER NOT NULL,

--- a/main.py
+++ b/main.py
@@ -118,6 +118,8 @@ def add_jeu(
     titre: str = Form(...),
     auteur: str = Form(...),
     ia_nom: str = Form(""),
+    nom_de_la_voie: str = Form(""),
+    voie_actif: bool = Form(False),
     synopsis: str = Form(""),
     motdepasse: str = Form(""),
 ):
@@ -125,8 +127,8 @@ def add_jeu(
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO jeux (titre, auteur, ia_nom, synopsis, mot_de_passe) VALUES (%s, %s, %s, %s, %s)",
-                (titre, auteur, ia_nom, synopsis, motdepasse),
+                "INSERT INTO jeux (titre, auteur, ia_nom, synopsis, mot_de_passe, nom_de_la_voie, voie_actif) VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                (titre, auteur, ia_nom, synopsis, motdepasse, nom_de_la_voie or None, voie_actif),
             )
             conn.commit()
     ensure_game_dirs(titre)
@@ -163,6 +165,8 @@ def edit_jeu(
     titre: str = Form(...),
     auteur: str = Form(...),
     ia_nom: str = Form(""),
+    nom_de_la_voie: str = Form(""),
+    voie_actif: bool = Form(False),
     synopsis: str = Form(""),
     motdepasse: str = Form(""),
 ):
@@ -170,8 +174,8 @@ def edit_jeu(
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE jeux SET titre=%s, auteur=%s, ia_nom=%s, synopsis=%s, mot_de_passe=%s WHERE id_jeu=%s",
-                (titre, auteur, ia_nom, synopsis, motdepasse, jeu_id),
+                "UPDATE jeux SET titre=%s, auteur=%s, ia_nom=%s, nom_de_la_voie=%s, voie_actif=%s, synopsis=%s, mot_de_passe=%s WHERE id_jeu=%s",
+                (titre, auteur, ia_nom, nom_de_la_voie or None, voie_actif, synopsis, motdepasse, jeu_id),
             )
             conn.commit()
     ensure_game_dirs(titre)

--- a/templates/add_jeu.html
+++ b/templates/add_jeu.html
@@ -35,6 +35,14 @@
                     <input type="password" id="motdepasse" name="motdepasse" value="{{ jeu.motdepasse if jeu else '' }}">
                 </div>
                 <div class="form-group">
+                    <label for="nom_de_la_voie">Nom de la voie :</label>
+                    <input type="text" id="nom_de_la_voie" name="nom_de_la_voie" value="{{ jeu.nom_de_la_voie if jeu else '' }}">
+                </div>
+                <div class="form-group">
+                    <label for="voie_actif">Voie active :</label>
+                    <input type="checkbox" id="voie_actif" name="voie_actif" {% if jeu and jeu.voie_actif %}checked{% endif %}>
+                </div>
+                <div class="form-group">
                     <label for="date_creation">Date de création :</label>
                     <input type="text" id="date_creation" value="{{ jeu.date_creation if jeu else '' }}" readonly>
                 </div>


### PR DESCRIPTION
## Résumé
- ajoute deux nouvelles colonnes dans `jeux`
- affiche et modifie ces champs depuis la page de gestion des jeux

## Test
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68828d0d8934832a94f9dd7c09f66148