### PR TITLE
Gestion du TTS suivant la configuration du jeu

### DIFF
--- a/main.py
+++ b/main.py
@@ -544,7 +544,13 @@ def demarrer_jeu(request: Request, jeu_id: int):
     print("[DEBUG] ROUTE ACTUELLE : /play")
     message = f"Page {page['ordre']}, {jeu['titre']}"
     print("[DEBUG] Message à lire :", message)
-    audio = audio_for_message(message, slug, page["ordre"])
+    audio = audio_for_message(
+        message,
+        slug,
+        page["ordre"],
+        voix=jeu.get("nom_de_la_voie"),
+        voix_active=jeu.get("voie_actif", True),
+    )
 
     response = templates.TemplateResponse(
         "play_page.html",
@@ -583,7 +589,13 @@ def afficher_page(request: Request, jeu_id: int, page_id: int):
     print("[DEBUG] ROUTE ACTUELLE : /play")
     message = f"Page {page['ordre']}, {jeu['titre']}"
     print("[DEBUG] Message à lire :", message)
-    audio = audio_for_message(message, slug, page["ordre"])
+    audio = audio_for_message(
+        message,
+        slug,
+        page["ordre"],
+        voix=jeu.get("nom_de_la_voie"),
+        voix_active=jeu.get("voie_actif", True),
+    )
 
     response = templates.TemplateResponse(
         "play_page.html",
@@ -622,7 +634,13 @@ def jouer_page(request: Request, jeu_id: int, page_id: int, saisie: str = Form("
             page = charger_page(conn, transition["id_page_cible"])
 
     slug = slugify(jeu["titre"])
-    audio = audio_for_message(message, slug, page["ordre"])
+    audio = audio_for_message(
+        message,
+        slug,
+        page["ordre"],
+        voix=jeu.get("nom_de_la_voie"),
+        voix_active=jeu.get("voie_actif", True),
+    )
     response = templates.TemplateResponse(
         "play_page.html",
         {


### PR DESCRIPTION
## Résumé
- activation ou non du TTS selon `voie_actif`
- propagation du nom de la voix aux appels `audio_for_message`

## Tests
- `python -m py_compile jouer.py main.py`

------
https://chatgpt.com/codex/tasks/task_b_68828f338be4832abec5c8409295bd46