### PR TITLE
Ajout zones interactives

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,24 @@ Il est également possible d'attendre directement la fonction :
 ```python
 audio_ok = await ds9_parle_async("Henriette Usha", "Bonjour", "static/tmp", "out.wav")
 ```
+
+## Zones interactives sur les pages
+
+Le contenu d'une page peut inclure des boutons ou des zones invisibles afin de
+proposer des actions directes au joueur. Il suffit d'ajouter une balise dans le
+champ **Contenu** lors de l'édition de la page. La classe `zone-action` place
+l'élément en position absolue et change le curseur de la souris. Avec la classe
+complémentaire `zone-invisible`, la zone devient transparente mais reste
+cliquable.
+
+Exemple :
+
+```html
+<button class="zone-action" data-saisie="ouvrir porte" style="top:50px;left:80px;">Porte</button>
+```
+
+Pour rendre la zone totalement invisible :
+
+```html
+<button class="zone-action zone-invisible" data-saisie="inspecter bureau" style="top:120px;left:30px;"></button>
+```

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -4,6 +4,15 @@
     <meta charset="utf-8">
     <title>{{ jeu.titre }}</title>
     <link rel="stylesheet" href="/static/jeux/{{ slug }}/{{ slug }}.css">
+    <style>
+        .zone-action {
+            position: absolute;
+            cursor: pointer;
+        }
+        .zone-invisible {
+            opacity: 0;
+        }
+    </style>
     {% if page.image_fond %}
     <style>
         body {
@@ -94,5 +103,17 @@ const interval = setInterval(() => {
 }, 1000);
 </script>
 {% endif %}
+<script>
+document.querySelectorAll('[data-saisie]').forEach(el => {
+    el.addEventListener('click', () => {
+        const form = document.querySelector('form');
+        const input = document.getElementById('saisie');
+        if (form && input) {
+            input.value = el.dataset.saisie;
+            form.requestSubmit();
+        }
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Résumé
- ajout des classes `.zone-action` et `.zone-invisible` dans le template `play_page.html`
- ajout d'un script permettant de saisir automatiquement la valeur d'un élément `data-saisie`
- documentation des zones interactives dans le README

## Tests
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68838a878f34832ab24e6f361fd64913