### PR TITLE
Ajout du champ est_aide

### DIFF
--- a/Station72.session.sql
+++ b/Station72.session.sql
@@ -9,6 +9,9 @@ ADD COLUMN enigme_texte TEXT DEFAULT NULL COMMENT 'Texte de l''énigme',
 ADD COLUMN bouton_texte TEXT DEFAULT NULL COMMENT 'Libellé du bouton',
 ADD COLUMN erreur_texte TEXT DEFAULT NULL COMMENT 'Message en cas d''erreur';
 
+ALTER TABLE pages
+ADD COLUMN est_aide BOOLEAN DEFAULT FALSE COMMENT 'Page d''aide';
+
 ALTER TABLE jeux
 ADD COLUMN ia_nom TEXT DEFAULT NULL COMMENT 'Nom de l\'IA';
 

--- a/main.py
+++ b/main.py
@@ -216,6 +216,7 @@ def add_page(
     page_suivante: str = Form(""),
     musique: str = Form(""),
     image_fond: str = Form(""),
+    est_aide: bool = Form(False),
     enigme_texte: str = Form(""),
     bouton_texte: str = Form(""),
     erreur_texte: str = Form(""),
@@ -225,7 +226,7 @@ def add_page(
         with conn.cursor() as cur:
             next_page = int(page_suivante) if page_suivante else None
             cur.execute(
-                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, enigme_texte, bouton_texte, erreur_texte, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, est_aide, enigme_texte, bouton_texte, erreur_texte, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     jeu_id,
                     titre,
@@ -234,6 +235,7 @@ def add_page(
                     next_page,
                     musique,
                     image_fond,
+                    est_aide,
                     enigme_texte,
                     bouton_texte,
                     erreur_texte,
@@ -286,6 +288,7 @@ def edit_page(
     page_suivante: str = Form(""),
     musique: str = Form(""),
     image_fond: str = Form(""),
+    est_aide: bool = Form(False),
     enigme_texte: str = Form(""),
     bouton_texte: str = Form(""),
     erreur_texte: str = Form(""),
@@ -295,7 +298,7 @@ def edit_page(
         with conn.cursor() as cur:
             next_page = int(page_suivante) if page_suivante else None
             cur.execute(
-                "UPDATE pages SET titre=%s, ordre=%s, delai_fermeture=%s, page_suivante=%s, musique=%s, image_fond=%s, enigme_texte=%s, bouton_texte=%s, erreur_texte=%s, contenu=%s WHERE id_page=%s",
+                "UPDATE pages SET titre=%s, ordre=%s, delai_fermeture=%s, page_suivante=%s, musique=%s, image_fond=%s, est_aide=%s, enigme_texte=%s, bouton_texte=%s, erreur_texte=%s, contenu=%s WHERE id_page=%s",
                 (
                     titre,
                     ordre,
@@ -303,6 +306,7 @@ def edit_page(
                     next_page,
                     musique,
                     image_fond,
+                    est_aide,
                     enigme_texte,
                     bouton_texte,
                     erreur_texte,
@@ -330,12 +334,12 @@ def duplicate_page(page_id: int):
     with get_conn() as conn:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
-                "SELECT id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, enigme_texte, bouton_texte, erreur_texte, contenu FROM pages WHERE id_page=%s",
+                "SELECT id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, est_aide, enigme_texte, bouton_texte, erreur_texte, contenu FROM pages WHERE id_page=%s",
                 (page_id,),
             )
             page = cur.fetchone()
             cur.execute(
-                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, enigme_texte, bouton_texte, erreur_texte, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                "INSERT INTO pages (id_jeu, titre, ordre, delai_fermeture, page_suivante, musique, image_fond, est_aide, enigme_texte, bouton_texte, erreur_texte, contenu) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     page["id_jeu"],
                     page["titre"],
@@ -344,6 +348,7 @@ def duplicate_page(page_id: int):
                     page["page_suivante"],
                     page["musique"],
                     page["image_fond"],
+                    page["est_aide"],
                     page["enigme_texte"],
                     page["bouton_texte"],
                     page["erreur_texte"],

--- a/templates/add_page.html
+++ b/templates/add_page.html
@@ -50,6 +50,10 @@
                     <label for="image_fond">Image de fond :</label>
                     <input type="text" id="image_fond" name="image_fond" value="{{ page.image_fond if page else '' }}">
                 </div>
+                <div class="form-group">
+                    <label for="est_aide">Page d'aide :</label>
+                    <input type="checkbox" id="est_aide" name="est_aide" {% if page and page.est_aide %}checked{% endif %}>
+                </div>
             </div>
             <div class="form-inline">
                 <div class="form-group">

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -121,6 +121,7 @@
     });
     </script>
 {% endif %}
+{% if not page.est_aide %}
     <div class="text-container text-container-bottom">
         <form class="input-ligne-unifiee" action="/play/{{ jeu.id_jeu }}/{{ page.id_page }}" method="post">
             {% if page.enigme_texte %}
@@ -130,6 +131,7 @@
             <button class="btn-go" type="submit">{{ page.bouton_texte or 'GO' }}</button>
         </form>
     </div>
+{% endif %}
 
 </div>
 {% if page.delai_fermeture and page.page_suivante %}


### PR DESCRIPTION
## Résumé
- ajout du champ `est_aide` dans la table `pages`
- prise en compte de ce champ dans les formulaires d'ajout et de modification de page
- mise à jour de la duplication et des requêtes SQL associées
- masquage du formulaire de saisie sur `play_page.html` quand la page est déclarée comme aide

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883e6e00b74832ab370bd6d863d17fb