### PR TITLE
Masquer la saisie sur les pages d'aide

### DIFF
--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -12,6 +12,9 @@
         .zone-invisible {
             opacity: 0;
         }
+        .cache {
+            display: none;
+        }
     </style>
     {% if page.image_fond %}
     <style>
@@ -121,8 +124,7 @@
     });
     </script>
 {% endif %}
-{% if not page.est_aide %}
-    <div class="text-container text-container-bottom">
+    <div class="text-container text-container-bottom{% if page.est_aide %} cache{% endif %}">
         <form class="input-ligne-unifiee" action="/play/{{ jeu.id_jeu }}/{{ page.id_page }}" method="post">
             {% if page.enigme_texte %}
                 <label for="saisie">{{ page.enigme_texte }}</label>
@@ -131,7 +133,6 @@
             <button class="btn-go" type="submit">{{ page.bouton_texte or 'GO' }}</button>
         </form>
     </div>
-{% endif %}
 
 </div>
 {% if page.delai_fermeture and page.page_suivante %}


### PR DESCRIPTION
## Résumé
- ajoute une classe `cache` pour masquer un élément
- conserve le formulaire de saisie sur les pages marquées comme aide mais le cache simplement

## Tests
- `python -m compileall -q jouer.py main.py ds9_ia.py ds9_tts.py ds9_fonctions_externes.py`

------
https://chatgpt.com/codex/tasks/task_b_6883e99316f4832a898fcbbb45b17aea