### PR TITLE
Gestion des PNJ et énigmes

### DIFF
--- a/Station72.session.sql
+++ b/Station72.session.sql
@@ -32,3 +32,21 @@ CREATE TABLE transitions (
     CONSTRAINT fk_page_source FOREIGN KEY (id_page_source) REFERENCES pages(id_page),
     CONSTRAINT fk_page_cible FOREIGN KEY (id_page_cible) REFERENCES pages(id_page)
 );
+
+CREATE TABLE pnj (
+    id SERIAL PRIMARY KEY,
+    nom VARCHAR(100) NOT NULL,
+    personae TEXT DEFAULT NULL,
+    prompt TEXT DEFAULT NULL,
+    date_creation TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE enigmes (
+    id SERIAL PRIMARY KEY,
+    id_pnj INTEGER NOT NULL,
+    texte_enigme TEXT NOT NULL,
+    texte_reponse TEXT NOT NULL,
+    textes_indices TEXT DEFAULT NULL,
+    date_creation TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_pnj FOREIGN KEY (id_pnj) REFERENCES pnj(id) ON DELETE CASCADE
+);

--- a/templates/add_enigme.html
+++ b/templates/add_enigme.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    {% if enigme %}
+    <title>Modifier une énigme</title>
+    {% else %}
+    <title>Ajouter une énigme</title>
+    {% endif %}
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        {% if enigme %}
+        <h1>✏️ Modifier une énigme</h1>
+        <form action="/enigmes/edit/{{ enigme.id }}" method="post">
+        {% else %}
+        <h1>➕ Ajouter une énigme</h1>
+        <form action="/enigmes/add" method="post">
+        {% endif %}
+            <input type="hidden" name="id_pnj" value="{{ enigme.id_pnj if enigme else pnj_id }}">
+            <div class="form-group">
+                <label for="texte_enigme">Énigme :</label>
+                <textarea id="texte_enigme" name="texte_enigme" rows="4">{{ enigme.texte_enigme if enigme else '' }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="texte_reponse">Réponse :</label>
+                <input type="text" id="texte_reponse" name="texte_reponse" value="{{ enigme.texte_reponse if enigme else '' }}">
+            </div>
+            <div class="form-group">
+                <label for="textes_indices">Indices :</label>
+                <textarea id="textes_indices" name="textes_indices" rows="4">{{ enigme.textes_indices if enigme else '' }}</textarea>
+            </div>
+            <div>
+                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                <a href="/pnj/edit/{{ enigme.id_pnj if enigme else pnj_id }}" class="btn btn-secondary">Annuler</a>
+            </div>
+        </form>
+    </div>
+</body>
+</html>

--- a/templates/add_pnj.html
+++ b/templates/add_pnj.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    {% if pnj %}
+    <title>Modifier un PNJ</title>
+    {% else %}
+    <title>Ajouter un PNJ</title>
+    {% endif %}
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        {% if pnj %}
+        <h1>✏️ Modifier un PNJ</h1>
+        <form action="/pnj/edit/{{ pnj.id }}" method="post">
+        {% else %}
+        <h1>➕ Ajouter un PNJ</h1>
+        <form action="/pnj/add" method="post">
+        {% endif %}
+            <div class="form-group">
+                <label for="nom">Nom :</label>
+                <input type="text" id="nom" name="nom" value="{{ pnj.nom if pnj else '' }}" required>
+            </div>
+            <div class="form-group">
+                <label for="personae">Personae :</label>
+                <textarea id="personae" name="personae" rows="3">{{ pnj.personae if pnj else '' }}</textarea>
+            </div>
+            <div class="form-group">
+                <label for="prompt">Prompt :</label>
+                <textarea id="prompt" name="prompt" rows="6">{{ pnj.prompt if pnj else '' }}</textarea>
+            </div>
+            <div>
+                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                <a href="/pnj" class="btn btn-secondary">Annuler</a>
+            </div>
+        </form>
+
+        {% if pnj %}
+        <h2>Énigmes du PNJ</h2>
+        <a href="/enigmes/add?pnj_id={{ pnj.id }}" class="btn btn-primary">Ajouter</a>
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Texte</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for e in enigmes %}
+                <tr>
+                    <td>{{ e.id }}</td>
+                    <td>{{ e.texte_enigme }}</td>
+                    <td>
+                        <a href="/enigmes/edit/{{ e.id }}" class="btn btn-secondary">Modifier</a>
+                        <a href="/enigmes/delete/{{ e.id }}" class="btn btn-danger" onclick="return confirm('Supprimer cette énigme ?');">Supprimer</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
     <div class="container">
         <h1>🎮 Gestion des jeux</h1>
         <a href="/jeux/add" class="btn btn-primary">➕ Ajouter un jeu</a>
+        <a href="/pnj" class="btn btn-primary">👤 Gestion des PNJ</a>
         <table>
             <thead>
                 <tr>

--- a/templates/pnj_index.html
+++ b/templates/pnj_index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Liste des PNJ</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>👤 Gestion des PNJ</h1>
+        <a href="/pnj/add" class="btn btn-primary">➕ Ajouter un PNJ</a>
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Nom</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in pnjs %}
+                <tr>
+                    <td>{{ p.id }}</td>
+                    <td>{{ p.nom }}</td>
+                    <td>
+                        <a href="/pnj/edit/{{ p.id }}" class="btn btn-secondary">Modifier</a>
+                        <a href="/pnj/delete/{{ p.id }}" class="btn btn-danger" onclick="return confirm('Supprimer ce PNJ ?');">Supprimer</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Résumé
- création des tables `pnj` et `enigmes`
- nouvelle interface pour gérer les PNJ et leurs énigmes
- ajout d'un lien vers la gestion des PNJ depuis la page principale
- nouvelles pages `pnj_index.html`, `add_pnj.html` et `add_enigme.html`

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6884bc0f169c832aa19f58f90511acc7