### PR TITLE
Ajout conversation PNJ

### DIFF
--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -138,6 +138,7 @@
                 <label for="saisie">{{ page.enigme_texte }}</label>
             {% endif %}
             <input class="champ-sombre" type="text" id="saisie" name="saisie" autofocus>
+            <input type="hidden" name="context" value="{{ context|e }}">
             <button class="btn-go" type="submit">{{ page.bouton_texte or 'GO' }}</button>
         </form>
     </div>


### PR DESCRIPTION
## Résumé
- permet de conserver le contexte d'une discussion avec un PNJ
- relance l'IA si la réponse n'est pas une intention
- transmet le contexte via le formulaire HTML

## Tests
- `python -m py_compile jouer.py`

------
https://chatgpt.com/codex/tasks/task_b_6884fcd6a90c832a96bcc3d90522f1f4