### PR TITLE
Ajout d'un prompt PNJ réutilisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,8 @@ Pour rendre la zone totalement invisible :
 Il est possible d'intégrer un marqueur `<!--tts:<voice>Nom de la voix</voice><texte>Votre texte</texte>-->` dans le champ **Contenu** d'une page.
 Le texte ainsi indiqué est converti en audio et joué dès l'affichage de la page,
 sans apparaître à l'écran. La balise `<voice>` permet de choisir la voix utilisée.
+
+## Dialogue avec un PNJ
+
+Si une page est associée à un PNJ, un prompt de base est construit à partir de la fiche du personnage et de ses énigmes. Ce prompt est conservé dans un champ caché et réutilisé à chaque échange.
+Tant qu'aucune intention définie n'est reconnue, l'historique du dialogue est envoyé à l'IA Mistral pour générer la réplique suivante du PNJ.

--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -139,6 +139,7 @@
             {% endif %}
             <input class="champ-sombre" type="text" id="saisie" name="saisie" autofocus>
             <input type="hidden" name="context" value="{{ context|e }}">
+            <input type="hidden" name="base_prompt" value="{{ base_prompt|e }}">
             <button class="btn-go" type="submit">{{ page.bouton_texte or 'GO' }}</button>
         </form>
     </div>


### PR DESCRIPTION
## Résumé
- conservez le prompt de base d'un PNJ entre chaque message
- passez ce prompt via le formulaire `play_page.html`
- documentez le dialogue avec un PNJ

## Tests
- `python -m py_compile jouer.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68865002cc90832ab52bb3128574ab2f