### PR TITLE
Désactive l’historique de saisie

### DIFF
--- a/templates/play_page.html
+++ b/templates/play_page.html
@@ -137,7 +137,7 @@
             {% if page.enigme_texte %}
                 <label for="saisie">{{ page.enigme_texte }}</label>
             {% endif %}
-            <input class="champ-sombre" type="text" id="saisie" name="saisie" autofocus>
+            <input class="champ-sombre" type="text" id="saisie" name="saisie" autofocus autocomplete="off">
             <input type="hidden" name="context" value="{{ context|e }}">
             <input type="hidden" name="base_prompt" value="{{ base_prompt|e }}">
             <button class="btn-go" type="submit">{{ page.bouton_texte or 'GO' }}</button>


### PR DESCRIPTION
## Résumé
- empêche l'autocomplétion du champ `saisie` dans la page de jeu

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688651d33588832aa33d1ad2043be0c2